### PR TITLE
Resolve dynamic docker host ports in lifecycle tests

### DIFF
--- a/tests/test_calendar_lifecycle.py
+++ b/tests/test_calendar_lifecycle.py
@@ -10,14 +10,32 @@ Usage:
 import asyncio
 import logging
 import os
+import subprocess
 from datetime import datetime, timedelta
+from pathlib import Path
 
 from dotenv import load_dotenv
 
 load_dotenv()
 
-# Default to localhost for tests running outside Docker
-os.environ.setdefault("CALDAV_URL", "http://localhost:5232")
+_COMPOSE = Path(__file__).resolve().parent.parent / "docker" / "docker-compose.yaml"
+
+
+def _docker_host_port(service: str, container_port: int) -> str | None:
+    """Resolve the host port docker-compose assigned to a service's container port."""
+    try:
+        out = subprocess.check_output(
+            ["docker", "compose", "-f", str(_COMPOSE), "port", service, str(container_port)],
+            stderr=subprocess.DEVNULL, text=True,
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+    return out.rsplit(":", 1)[1] if ":" in out else None
+
+
+if "CALDAV_URL" not in os.environ:
+    _port = _docker_host_port("radicale", 5232) or "5232"
+    os.environ["CALDAV_URL"] = f"http://localhost:{_port}"
 
 from clawmark.state.calendar import CalendarStateManager
 

--- a/tests/test_email_lifecycle.py
+++ b/tests/test_email_lifecycle.py
@@ -12,16 +12,34 @@ Usage:
 import asyncio
 import logging
 import os
+import subprocess
+from pathlib import Path
 
 from dotenv import load_dotenv
 
 load_dotenv()
 
-# Default to localhost for tests running outside Docker
+_COMPOSE = Path(__file__).resolve().parent.parent / "docker" / "docker-compose.yaml"
+
+
+def _docker_host_port(service: str, container_port: int) -> str | None:
+    """Resolve the host port docker-compose assigned to a service's container port."""
+    try:
+        out = subprocess.check_output(
+            ["docker", "compose", "-f", str(_COMPOSE), "port", service, str(container_port)],
+            stderr=subprocess.DEVNULL, text=True,
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+    return out.rsplit(":", 1)[1] if ":" in out else None
+
+
 os.environ.setdefault("EMAIL_IMAP_SERVER", "localhost")
-os.environ.setdefault("EMAIL_IMAP_PORT", "3143")
 os.environ.setdefault("EMAIL_SMTP_SERVER", "localhost")
-os.environ.setdefault("EMAIL_SMTP_PORT", "3025")
+if "EMAIL_IMAP_PORT" not in os.environ:
+    os.environ["EMAIL_IMAP_PORT"] = _docker_host_port("greenmail", 3143) or "3143"
+if "EMAIL_SMTP_PORT" not in os.environ:
+    os.environ["EMAIL_SMTP_PORT"] = _docker_host_port("greenmail", 3025) or "3025"
 
 from clawmark.state.email import EmailStateManager
 


### PR DESCRIPTION
## Summary
- `docker/docker-compose.yaml` publishes Radicale/GreenMail on ephemeral host ports (`127.0.0.1:0:PORT`), so the hardcoded defaults `5232` / `3143` / `3025` in `tests/test_calendar_lifecycle.py` and `tests/test_email_lifecycle.py` fail with connection refused when run from the host.
- Added a small `_docker_host_port(service, container_port)` helper that shells out to `docker compose port` and fills in the `CALDAV_URL` / `EMAIL_IMAP_PORT` / `EMAIL_SMTP_PORT` env vars. Explicit env vars still win; the hardcoded ports remain as a final fallback.

## Test plan
- [x] `uv run python tests/test_calendar_lifecycle.py` — ALL STEPS PASSED
- [x] `uv run python tests/test_email_lifecycle.py` — ALL STEPS PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)