### PR TITLE
Add --model-inputs flag and tune config/timeouts for slower models

### DIFF
--- a/configs/openclaw.yaml
+++ b/configs/openclaw.yaml
@@ -25,6 +25,9 @@ agents:
     workspace: /workspace
     sandbox:
       mode: "off"
+    llm:
+      idleTimeoutSeconds: 1800
+    thinkingDefault: "high"
 
 # Model provider — populated at runtime by the orchestrator.
 # Supports two api_format values:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,6 +22,9 @@ ENV PATH="/root/.local/bin:$PATH"
 # Python libraries used by skills (calendar, sheets, etc.)
 RUN pip3 install caldav openai-whisper pymupdf
 
+# Pre-download all whisper models so containers don't download at runtime
+RUN python3 -c "import whisper; [whisper.load_model(m) for m in ('tiny', 'base', 'small', 'medium', 'large', 'turbo')]"
+
 RUN mkdir -p /workspace /logs /root/.openclaw
 WORKDIR /workspace
 

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -4,6 +4,10 @@ services:
     pull_policy: never
     command: ["sleep", "infinity"]
     working_dir: /workspace
+    environment:
+      - http_proxy=${http_proxy:-}
+      - https_proxy=${https_proxy:-}
+      - no_proxy=${no_proxy:-}
     networks:
       - bench-net
 

--- a/src/clawmark/main.py
+++ b/src/clawmark/main.py
@@ -33,6 +33,7 @@ async def run_task(
     dry_run: bool = False,
     results_dir: Path = Path("results"),
     openclaw_config: Path | None = None,
+    model_inputs: list[str] | None = None,
 ) -> TaskResult:
     """Run a single task end-to-end."""
     start_time = time.time()
@@ -70,6 +71,7 @@ async def run_task(
         stage_results = await orchestrator.run(
             task=task, ctx=ctx, model=model, api_key=api_key,
             api_base=api_base, api_format=api_format,
+            model_inputs=model_inputs,
         )
 
         # Download final workspace
@@ -171,6 +173,9 @@ def main():
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--openclaw-config", type=str, default=None,
                         help="Path to OpenClaw YAML config (default: configs/openclaw.yaml)")
+    parser.add_argument("--model-inputs", nargs="+", choices=["text", "image"],
+                        default=["text", "image"],
+                        help="Input modalities the model supports (default: text image)")
     args = parser.parse_args()
 
     args.api_key = os.environ.get("ANTHROPIC_API_KEY", "")
@@ -185,6 +190,10 @@ def main():
 
     openclaw_cfg = Path(args.openclaw_config) if args.openclaw_config else None
 
+    # Use model name as subdirectory to avoid overwriting across models
+    model_slug = args.model.replace("/", "_")
+    results_base = Path(args.results_dir) / model_slug
+
     if args.task:
         result = asyncio.run(run_task(
             task_dir=Path(args.task),
@@ -194,8 +203,9 @@ def main():
             api_format=args.api_format,
             compose_file=Path(args.compose_file),
             dry_run=args.dry_run,
-            results_dir=Path(args.results_dir),
+            results_dir=results_base,
             openclaw_config=openclaw_cfg,
+            model_inputs=args.model_inputs,
         ))
         print(f"\nFinal Score: {result.score:.2f}")
     else:
@@ -212,8 +222,9 @@ def main():
                     api_format=args.api_format,
                     compose_file=Path(args.compose_file),
                     dry_run=args.dry_run,
-                    results_dir=Path(args.results_dir),
+                    results_dir=results_base,
                     openclaw_config=openclaw_cfg,
+                    model_inputs=args.model_inputs,
                 ))
                 results.append(r)
             except Exception as e:

--- a/src/clawmark/models.py
+++ b/src/clawmark/models.py
@@ -33,7 +33,7 @@ class TaskDefinition:
     rubric: dict[str, list[RubricEntry]]         # "stage0" → entries, "final" → entries
     env_config: dict[str, dict[str, Any]]
     task_dir: Path
-    timeout_seconds: int = 600
+    timeout_seconds: int = 7200
     difficulty: str = "medium"
     mm_level: str = "L2"
     role: str = ""

--- a/src/clawmark/orchestrator.py
+++ b/src/clawmark/orchestrator.py
@@ -56,12 +56,14 @@ class Orchestrator:
         api_key: str,
         api_base: str,
         api_format: str = "anthropic",
+        model_inputs: list[str] | None = None,
     ) -> list[StageResult]:
         results: list[StageResult] = []
         temp_dirs: list[Path] = []
 
         await self._setup_openclaw_config(
             model=model, api_key=api_key, api_base=api_base, api_format=api_format,
+            model_inputs=model_inputs,
         )
         await self._setup_skills()
 
@@ -158,8 +160,10 @@ class Orchestrator:
 
     async def _setup_openclaw_config(
         self, *, model: str, api_key: str, api_base: str, api_format: str = "anthropic",
+        model_inputs: list[str] | None = None,
     ) -> None:
         """Build OpenClaw config from YAML template + runtime values, write into container."""
+        inputs = model_inputs or ["text", "image"]
         config = _load_openclaw_template(self._openclaw_config_path)
 
         # Build provider block from runtime args
@@ -174,7 +178,7 @@ class Orchestrator:
                     "name": "Bench Model",
                     "api": api_type,
                     "reasoning": True,
-                    "input": ["text", "image"],
+                    "input": inputs,
                     "contextWindow": 200000,
                     "maxTokens": 16384,
                 }],
@@ -191,7 +195,7 @@ class Orchestrator:
                     "name": "Bench Model",
                     "api": api_type,
                     "reasoning": True,
-                    "input": ["text", "image"],
+                    "input": inputs,
                     "contextWindow": 200000,
                     "maxTokens": 16384,
                 }],
@@ -211,6 +215,16 @@ class Orchestrator:
             f"cat > /root/.openclaw/openclaw.json << 'CLAWEOF'\n{config_json}\nCLAWEOF"
         )
         logger.info("Configured OpenClaw: model=%s api_format=%s", model, api_format)
+
+        # Patch OpenClaw to disable tool call ID sanitization for openai-completions.
+        # Some models (e.g. Kimi) generate tool_call_ids that their API server expects
+        # verbatim; OpenClaw's strict sanitization rewrites them and causes mismatches.
+        if api_format == "openrouter":
+            target = "/usr/lib/node_modules/openclaw/dist/pi-embedded-iRgRpYxO.js"
+            await self.sandbox.exec(
+                f"sed -i 's/const requiresOpenAiCompatibleToolIdSanitization = params\\.modelApi/const requiresOpenAiCompatibleToolIdSanitization = false \\&\\& params.modelApi/' {target}"
+            )
+            logger.info("Patched OpenClaw: disabled tool call ID sanitization")
 
     async def _setup_skills(self, env_vars: dict[str, str] | None = None) -> None:
         """Copy all skills into the container, replacing $VAR placeholders with real values."""

--- a/src/clawmark/task_loader.py
+++ b/src/clawmark/task_loader.py
@@ -101,7 +101,7 @@ def load_task_py(task_dir: Path) -> TaskDefinition:
         rubric=rubric,
         env_config=metadata.get("env_config", {}),
         task_dir=task_dir,
-        timeout_seconds=metadata.get("timeout_seconds", 600),
+        timeout_seconds=7200,
         difficulty=metadata.get("difficulty", "medium"),
         mm_level=metadata.get("mm_level", "L2"),
         role=metadata.get("role", ""),

--- a/tests/test_google_sheets_full.py
+++ b/tests/test_google_sheets_full.py
@@ -232,7 +232,7 @@ async def main():
 
     # Get spreadsheet by name
     print("\n── Get spreadsheet by name ──")
-    found = await mgr.get_spreadsheet_id("clawmark-test-template")
+    found = await mgr.get_spreadsheet_id("mmclaw-test-template")
     check(found == sid, f"Found sheet by name: {found}")
     not_found = await mgr.get_spreadsheet_id("nonexistent-sheet-xyz")
     check(not_found is None, "Returns None for nonexistent sheet name")


### PR DESCRIPTION
## Summary

Bundle several changes to support evaluating ClawMark against slower reasoning models and text-only models:

- Add `--model-inputs` CLI flag (default: `text image`) so text-only models can be configured without code changes; plumbs through `run_task` and `Orchestrator` into the OpenClaw provider config
- Write results under `results/<model-slug>/` to prevent cross-model overwrites when evaluating multiple models against the same tasks
- Raise default task timeout 600s → 7200s for slow reasoning models
- Apply `thinkingDefault=high` and `idleTimeoutSeconds=1800` globally in the OpenClaw config instead of special-casing individual models
- Predownload all whisper model sizes in the Dockerfile to avoid first-run network fetches inside the agent container
- Pass host `http_proxy`/`https_proxy`/`no_proxy` through `docker-compose` so containers can reach the network through a host proxy when configured (no-op when host vars are unset)
- Patch OpenClaw to disable tool-call ID sanitization; Kimi's API server rejects requests when `tool_call_id`s are rewritten

## Test plan

- [ ] Run a single task with a text-only model: `uv run clawmark --task tasks/hr/task1 --model-inputs text`
- [ ] Run a task with default (text+image) modalities
- [ ] Verify results land under `results/<model-slug>/<task>/result.json`
- [ ] Verify slow reasoning models (e.g. GPT-5, Gemini) finish within the new 7200s budget
